### PR TITLE
Added Linux build

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,12 +67,11 @@ const createWindow = () => {
     win.setSkipTaskbar(true)
     win.hide()
 
-    const macTrayImage = 'nookTemplate.png'
+    const altTrayImage = 'nookTemplate.png'
     const trayImage = 'nookTray.png'
-    const trayIcon =
-      os.platform() === 'darwin'
-        ? nativeImage.createFromPath(path.join(assets, macTrayImage))
-        : nativeImage.createFromPath(path.join(assets, trayImage))
+    const trayIcon = (['darwin', 'linux'].some(p => p === os.platform()))
+      ? nativeImage.createFromPath(path.join(assets, altTrayImage))
+      : nativeImage.createFromPath(path.join(assets, trayImage))
     const trayMenu = Menu.buildFromTemplate([
       {
         label: 'Exit',

--- a/package.json
+++ b/package.json
@@ -43,9 +43,10 @@
       "artifactName": "${productName}.${ext}",
       "icon": "build/icons/nook.icns",
       "target": [
-        "AppImage",
         "deb",
-        "pacman"
+        "pacman",
+        "rpm",
+        "flatpak"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "release": "env-cmd electron-builder",
     "lint": "standard"
   },
-  "author": "mn6",
+  "author": "mn6 <idont@knowyouremail.com>",
   "license": "ISC",
   "build": {
     "extraResources": [
@@ -37,6 +37,15 @@
       "icon": "build/icons/nook.png",
       "target": [
         "nsis-web"
+      ]
+    },
+    "linux": {
+      "artifactName": "${productName}.${ext}",
+      "icon": "build/icons/nook.icns",
+      "target": [
+        "AppImage",
+        "deb",
+        "pacman"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
         "pacman",
         "rpm",
         "flatpak"
-      ]
+      ],
+      "category": "Audio;Music;Player;AudioVideo"
     }
   },
   "publish": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       ]
     },
     "linux": {
-      "artifactName": "${productName}.${ext}",
+      "artifactName": "${name}.${ext}",
       "icon": "build/icons/nook.icns",
       "target": [
         "deb",


### PR DESCRIPTION
Closes #11 
Should allow the next update to include Linux builds of Nook Desktop
I have included 3 versions for different distros: `.deb` for Debian-based distros, `.pacman` for Arch-based distros, `.rpm` for the various distros that use that format, and `.flatpak` for everything else:
![image](https://user-images.githubusercontent.com/48618519/223270479-df8e49c1-72ec-411b-b2a8-66e26cf909d3.png)
Here is proof of it working on a Manjaro install:
![image](https://user-images.githubusercontent.com/48618519/223134550-874e8963-d648-4729-9521-9d2a0b0e6ccc.png)
![image](https://user-images.githubusercontent.com/48618519/223133950-8dc91c95-1439-4cf7-9baa-e700ffdd46d9.png)

Successfully tested on the following distros:
Manjaro + KDE
Manjaro + Gnome
Archcraft + BSPWM
Arco Linux + KDE
Clear Linux + Gnome
Void Linux + Gnome


## ⚠️IMPORTANT⚠️
Building .deb applications requires your email address to be in your package.json file. I do not know your email address, so I put this instead:
![image](https://user-images.githubusercontent.com/48618519/218730753-25221c9f-b376-4431-8707-3eb69dcd0e21.png)
This should really be changed before releasing 😅

(this description has been retroactively updated as the PR has changes, which is why some changes mentioned here show up in the commit messages below)