### PR TITLE
Add open on startup option

### DIFF
--- a/app/hidden/player.js
+++ b/app/hidden/player.js
@@ -34,6 +34,7 @@ let gameRain
 let peacefulRain
 let kkEnabled
 let kkSaturday
+let openOnStartup
 let preferNoDownload
 let latestVersion
 let currentVersion
@@ -378,6 +379,10 @@ const handleIpc = async (event, arg) => {
     const gameUrl = game === 'random' ? games[~~(Math.random() * games.length)] : game
     await stopAudio('sound')
     await playSound(await getUrl(`${baseUrl}/${gameUrl}/${gameUrl === 'kk-slider-desktop' ? kkEnabled[~~(Math.random() * kkEnabled.length)] : gameUrl === 'pocket-camp' ? hourToPocketCamp(hour) : hour}.ogg`))
+  } else if (command === 'openOnStartup') {
+    openOnStartup = arg[0]
+    storage.set('openOnStartup', { enabled: arg[0] })
+    ipc.send('openOnStartup', [arg[0]])
   } else if (command === 'lang') {
     lang = arg[0]
     storage.set('lang', { lang: arg[0] })
@@ -470,6 +475,7 @@ const doMain = () => {
   peacefulRain = storage.getSync('peacefulRain').enabled
   kkEnabled = storage.getSync('kkEnabled').songs
   kkSaturday = storage.getSync('kkSaturday').enabled
+  openOnStartup = storage.getSync('openOnStartup').enabled
   latestVersion = storage.getSync('latestVersion').version
   let showChangelog = false
 
@@ -494,6 +500,7 @@ const doMain = () => {
   if (peacefulRain === undefined) peacefulRain = false
   if (kkEnabled === undefined) kkEnabled = kkSongs
   if (kkSaturday === undefined) kkSaturday = false
+  if (openOnStartup === undefined) openOnStartup = false
   if (tune === undefined) {
     tune = [
       'G1',
@@ -515,7 +522,7 @@ const doMain = () => {
     ]
   }
 
-  ipc.send('toWindow', ['configs', { soundVol: soundVol * 100, rainVol: rainVol * 100, grandFather, game, lang, offlineFiles, offlineKKFiles, tune, tuneEnabled, preferNoDownload, paused, gameRain, peacefulRain, kkEnabled, kkSaturday, showChangelog }])
+  ipc.send('toWindow', ['configs', { soundVol: soundVol * 100, rainVol: rainVol * 100, grandFather, game, lang, offlineFiles, offlineKKFiles, tune, tuneEnabled, preferNoDownload, paused, gameRain, peacefulRain, kkEnabled, kkSaturday, openOnStartup, showChangelog }])
 
   superagent
     .get('https://cms.mat.dog/getSupporters')

--- a/app/main/i18n/Nook_Chinese.json
+++ b/app/main/i18n/Nook_Chinese.json
@@ -53,6 +53,7 @@
     "AC: New Horizons (Switch) [Snowy]": "集合啦！动物森友会 (Switch) [雪天]",
     "AC: Pocket Camp (Mobile)": "动物森友会：口袋露营广场 (移动版)",
     "Play K.K. music on Saturday nights": "周六晚上播放 K.K. 音乐",
+    "Open on startup": "开机启动",
     "customize k.k. playlist": "自定义 k.k. 播放列表",
     "customize town tune": "自定义小镇主题曲",
     "k.k. playlist": "k.k. 播放列表",

--- a/app/main/i18n/Nook_English.json
+++ b/app/main/i18n/Nook_English.json
@@ -54,6 +54,7 @@
     "AC: New Horizons (Switch) [Snowy]": "AC: New Horizons (Switch) [Snowy]",
     "AC: Pocket Camp (Mobile)": "AC: Pocket Camp (Mobile)",
     "Play K.K. music on Saturday nights": "Play K.K. music on Saturday nights",
+    "Open on startup": "Open on startup",
     "customize k.k. playlist": "customize k.k. playlist",
     "customize town tune": "customize town tune",
     "k.k. playlist": "k.k. playlist",

--- a/app/main/i18n/Nook_French.json
+++ b/app/main/i18n/Nook_French.json
@@ -53,6 +53,7 @@
     "AC: New Horizons (Switch) [Snowy]": "AC: New Horizons (Switch) [Neige]",
     "AC: Pocket Camp (Mobile)": "AC: Pocket Camp (Mobile)",
     "Play K.K. music on Saturday nights": "Jouer la musique de Kéké le samedi soir",
+    "Open on startup": "Ouvrir au démarrage",
     "customize k.k. playlist": "personnaliser la liste de lecture de Kéké",
     "customize town tune": "personnaliser l'hymne",
     "k.k. playlist": "liste de lecture de Kéké",

--- a/app/main/i18n/Nook_German.json
+++ b/app/main/i18n/Nook_German.json
@@ -53,6 +53,7 @@
     "AC: New Horizons (Switch) [Snowy]": "AC: New Horizons (Switch) [Schnee]",
     "AC: Pocket Camp (Mobile)": "AC: Pocket Camp (Smartphone)",
     "Play K.K. music on Saturday nights": "K.K. Musik Samstag nachts abspielen",
+    "Open on startup": "Beim Start öffnen",
     "customize k.k. playlist": "K.K. Playlist anpassen",
     "customize town tune": "Stadtmelodie anpassen",
     "k.k. playlist": "K.K. Playlist",

--- a/app/main/i18n/Nook_Spanish.json
+++ b/app/main/i18n/Nook_Spanish.json
@@ -53,6 +53,7 @@
     "AC: New Horizons (Switch) [Snowy]": "AC: New Horizons (Switch) [Nevando]",
     "AC: Pocket Camp (Mobile)": "AC: Pocket Camp (Móvil)",
     "Play K.K. music on Saturday nights": "Tocar música K.K. sábados por la noche",
+    "Open on startup": "Abrir al iniciar",
     "customize k.k. playlist": "personalizar la lista de k.k.",
     "customize town tune": "personalizar la melodía de la ciudad",
     "k.k. playlist": "lista de k.k.",

--- a/app/main/js/main.js
+++ b/app/main/js/main.js
@@ -151,6 +151,10 @@ const template = `
             <input id="kkSaturday" type="checkbox"/>
             <span data-i18n="Play K.K. music on Saturday nights"></span>
           </label>
+          <label>
+              <input id="openOnStartup" type="checkbox"/>
+              <span data-i18n="Open on startup"></span>
+          </label>
           <div class="btnContainer">
             <button id="kkCustomize" data-i18n="customize k.k. playlist"></button>
             <button class="towntune-custom" id="towntune_customize" data-i18n="customize town tune"></button>
@@ -375,6 +379,7 @@ const changeLang = (lang, manual, arg) => {
       $('#townTune').prop('checked', arg.tuneEnabled)
       $('#preferNoDownload').prop('checked', arg.preferNoDownload)
       $('#kkSaturday').prop('checked', arg.kkSaturday)
+      $('#openOnStartup').prop('checked', arg.openOnStartup)
 
       arg.kkEnabled.forEach((song) => {
         $(`.kk-customize input[data-title="${song}"]`).prop('checked', true)
@@ -550,6 +555,10 @@ const exec = () => {
 
   $('.settings #kkSaturday').on('change', (e) => {
     ipc.send('toPlayer', ['kkSaturday', e.target.checked])
+  })
+
+  $('.settings #openOnStartup').on('change', (e) => {
+    ipc.send('toPlayer', ['openOnStartup', e.target.checked])
   })
 
   $('.settings #langSelect').on('change', (e) => {

--- a/index.js
+++ b/index.js
@@ -129,6 +129,12 @@ const createWindow = () => {
     ])
   })
 
+  ipcMain.on('openOnStartup', (event, args) => {
+    app.setLoginItemSettings({
+      openAtLogin: args[0]
+    })
+  })
+
   ipcMain.on('toPlayer', (event, args) => {
     hiddenWin.webContents.send('toPlayer', args)
   })


### PR DESCRIPTION
I've implemented an option that enables nook-desktop to auto-start after a user logs-in to their desktop.
![Nook_7o7cPwja6J](https://github.com/mn6/nook-desktop/assets/34954180/e8129d14-7c70-4cef-bf26-c87c6af2cd69)
