### PR TITLE
Add "Open on startup" Italian translation

### DIFF
--- a/app/main/i18n/Nook_Italian.json
+++ b/app/main/i18n/Nook_Italian.json
@@ -53,6 +53,7 @@
     "AC: New Horizons (Switch) [Snowy]": "AC: New Horizons (Switch) [Snowy]",
     "AC: Pocket Camp (Mobile)": "AC: Pocket Camp (Mobile)",
     "Play K.K. music on Saturday nights": "Suona K.K. musica il sabato sera",
+    "Open on startup": "Apri all'avvio",
     "customize k.k. playlist": "personalizza k.k. playlist",
     "customize town tune": "personalizza la melodia della città",
     "k.k. playlist": "k.k. playlist",


### PR DESCRIPTION
fixes missing "Open on startup" Italian translation.